### PR TITLE
Adds compatibility for both RGB and ARGB format

### DIFF
--- a/WindleKnot/MainWindow.xaml.cs
+++ b/WindleKnot/MainWindow.xaml.cs
@@ -65,7 +65,7 @@ namespace WindleKnot
                 Picture picture = new Picture();
 
                 //Change third parameter to what ever image index you want.
-                CanvasPicture.Source = picture.DrawPicture(resourceData, resourceMap, 0);
+                CanvasPicture.Source = picture.DrawPicture(resourceData, resourceMap, 430);
             }
         }
 

--- a/WindleKnot/Picture.cs
+++ b/WindleKnot/Picture.cs
@@ -100,7 +100,6 @@ namespace WindleKnot
             if (data[0x5E] == 0)
             {
                 PALETTE_ITEM_SIZE = 4;
-                PALETTE_OFFSET = 0x64;
             }
 
             // Extract palette data
@@ -108,16 +107,19 @@ namespace WindleKnot
             for (int i = PALETTE_OFFSET; i < offset + HEADER_LENGTHS; i += PALETTE_ITEM_SIZE)
             {
                 byte a = 1;
-
-                //Check if alpha ARGB format
-                if (PALETTE_ITEM_SIZE == 4)
-                {
-                    a = data[i - 1];
-                }
-
                 byte r = data[i];
                 byte g = data[i + 1];
                 byte b = data[i + 2];
+
+                //Check if using ARGB format
+                if (PALETTE_ITEM_SIZE == 4)
+                {
+                    a = data[i];
+                    r = data[i + 1];
+                    g = data[i + 2];
+                    b = data[i + 3];
+                }
+
                 palette.Add((a, r, g, b));
             }
 

--- a/WindleKnot/Picture.cs
+++ b/WindleKnot/Picture.cs
@@ -54,7 +54,7 @@ namespace WindleKnot
 
 
                         // Set the pixel color
-                        bitmap.SetPixel(col, row, System.Drawing.Color.FromArgb(r, g, b));
+                        bitmap.SetPixel(col, row, Color.FromArgb(a * 255, r, g, b));
                     }
                 }
 
@@ -68,7 +68,7 @@ namespace WindleKnot
         {
             using (MemoryStream memoryStream = new MemoryStream())
             {
-                // Save the System.Drawing.Bitmap to the memory stream in PNG format
+                // Save the Bitmap to the memory stream in PNG format
                 bitmap.Save(memoryStream, ImageFormat.Png);
                 memoryStream.Position = 0;
 

--- a/WindleKnot/Picture.cs
+++ b/WindleKnot/Picture.cs
@@ -12,9 +12,9 @@ namespace WindleKnot
 {
     internal class Picture
     {
-        public Picture() 
-        { 
-        
+        public Picture()
+        {
+
         }
 
         LZS lzs = new LZS();
@@ -29,12 +29,12 @@ namespace WindleKnot
 
             byte[] uncompressedData = lzs.Decompress(CompressedData, compressedSize, uncompressedSize, out outSize);
 
-            (byte[][] matrixData, List<(byte R, byte G, byte B)> palette) = GetImageDataWithPalette(uncompressedData);
+            (byte[][] matrixData, List<(byte A, byte R, byte G, byte B)> palette) = GetImageDataWithPalette(uncompressedData);
 
             return ConstructBitmapImage(matrixData, palette);
         }
 
-        public static BitmapImage ConstructBitmapImage(byte[][] matrixData, List<(byte R, byte G, byte B)> palette)
+        public static BitmapImage ConstructBitmapImage(byte[][] matrixData, List<(byte A, byte R, byte G, byte B)> palette)
         {
             int height = matrixData.Length;
             int width = matrixData[0].Length;
@@ -50,7 +50,7 @@ namespace WindleKnot
                         byte paletteIndex = matrixData[row][col];
 
                         // Get the RGB color from the palette
-                        var (r, g, b) = palette[paletteIndex];
+                        var (a, r, g, b) = palette[paletteIndex];
 
 
                         // Set the pixel color
@@ -59,7 +59,7 @@ namespace WindleKnot
                 }
 
                 BitmapImage bitmapImage = ConvertBitmapToBitmapImage(bitmap);
-                
+
                 return bitmapImage;
             }
         }
@@ -85,7 +85,7 @@ namespace WindleKnot
 
 
 
-        static (byte[][], List<(byte R, byte G, byte B)>) GetImageDataWithPalette(byte[] data)
+        static (byte[][], List<(byte A, byte R, byte G, byte B)>) GetImageDataWithPalette(byte[] data)
         {
             // Constants and header parsing
             int HEADER_LENGTHS = 0x44;
@@ -96,14 +96,29 @@ namespace WindleKnot
             int width = BitConverter.ToInt16(data, 0x0E); // Image width
             int height = BitConverter.ToInt16(data, 0x10); // Image height
 
+            //Determine if using RGB or ARGB Format
+            if (data[0x5E] == 0)
+            {
+                PALETTE_ITEM_SIZE = 4;
+                PALETTE_OFFSET = 0x64;
+            }
+
             // Extract palette data
-            var palette = new List<(byte R, byte G, byte B)>();
+            var palette = new List<(byte A, byte R, byte G, byte B)>();
             for (int i = PALETTE_OFFSET; i < offset + HEADER_LENGTHS; i += PALETTE_ITEM_SIZE)
             {
+                byte a = 1;
+
+                //Check if alpha ARGB format
+                if (PALETTE_ITEM_SIZE == 4)
+                {
+                    a = data[i - 1];
+                }
+
                 byte r = data[i];
                 byte g = data[i + 1];
                 byte b = data[i + 2];
-                palette.Add((r, g, b));
+                palette.Add((a, r, g, b));
             }
 
             // Extract the image data


### PR DESCRIPTION
Some pictures are defining ARGB data instead of just RGB data. This accounts for that. An example of a broken picture was index 430 (8346.p56).